### PR TITLE
rbt2.4 calc TSC once, fixes BW calcs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,9 +109,15 @@ elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
 endif()
 
-find_package(hsa-runtime64 REQUIRED
-   PATHS  /opt/rocm
+if (DEFINED ROCM_HOME)
+  find_package(hsa-runtime64 REQUIRED
+	  PATHS  ${ROCM_HOME}
   )
+else()
+  find_package(hsa-runtime64 REQUIRED
+    PATHS  /opt/rocm
+  )
+endif()
 message( " hsa-runtime64 found @  ${hsa-runtime64_DIR} " )
 
 # Set project requirements
@@ -159,6 +165,10 @@ target_link_libraries(${TEST_NAME} PRIVATE c stdc++ dl pthread rt)
 # Add --enable-new-dtags to generate DT_RUNPATH
 if( DEFINED ENV{ROCM_RPATH})
    set ( CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
+endif()
+
+if (DEFINED ROCM_HOME)
+	set ( CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,${ROCM_HOME}/hsa/lib:${ROCM_HOME}/lib64:${ROCM_HOME}/lib" )
 endif()
 
 # Add install directives for rocm_bandwidth_test

--- a/hsatimer.cpp
+++ b/hsatimer.cpp
@@ -45,8 +45,10 @@
 #define NANOSECONDS_PER_SECOND 1000000000
 
 PerfTimer::PerfTimer() {
-  freq_in_100mhz = MeasureTSCFreqHz();
+  freq_in_100mhz = PerfTimer::MeasureTSCFreqHz();
 }
+
+PerfTimer::PerfTimer(double tscfreq) : freq_in_100mhz{tscfreq} {}
 
 PerfTimer::~PerfTimer() {
   while (!_timers.empty()) {
@@ -176,13 +178,13 @@ uint64_t PerfTimer::MeasureTSCFreqHz() {
   unsigned int unused;
   uint64_t tscTicksEnd;
 
-  uint64_t coarseBeginUs = CoarseTimestampUs();
+  uint64_t coarseBeginUs = PerfTimer::CoarseTimestampUs();
   uint64_t tscTicksBegin = __rdtscp(&unused);
   do {
     tscTicksEnd = __rdtscp(&unused);
   } while (tscTicksEnd - tscTicksBegin < 1000000000);
 
-  uint64_t coarseEndUs = CoarseTimestampUs();
+  uint64_t coarseEndUs = PerfTimer::CoarseTimestampUs();
 
   // Compute the TSC frequency and round to nearest 100MHz.
   uint64_t coarseIntervalNs = (coarseEndUs - coarseBeginUs) * 1000;

--- a/hsatimer.hpp
+++ b/hsatimer.hpp
@@ -81,13 +81,14 @@ class PerfTimer {
  public:
 
   PerfTimer();
+  PerfTimer(double);
   ~PerfTimer();
 
  private:
 
   // AMD timing method
-  uint64_t CoarseTimestampUs();
-  uint64_t MeasureTSCFreqHz();
+  // uint64_t CoarseTimestampUs();
+  // uint64_t MeasureTSCFreqHz();
 
   // General Linux timing method
 
@@ -97,6 +98,8 @@ class PerfTimer {
   int StartTimer(int index);
   int StopTimer(int index);
   void ResetTimer(int index);
+  static uint64_t MeasureTSCFreqHz();
+  static uint64_t CoarseTimestampUs();
 
  public:
  

--- a/rocm_bandwidth_test.cpp
+++ b/rocm_bandwidth_test.cpp
@@ -588,7 +588,7 @@ void RocmBandwidthTest::RunCopyBenchmark(async_trans_t& trans) {
       }
 
       // Create a timer object and reset signals
-      PerfTimer timer;
+      PerfTimer timer(tscFreq);
       uint32_t index = timer.CreateTimer();
 
       // Start the timer and launch forward copy operation
@@ -803,8 +803,8 @@ RocmBandwidthTest::RocmBandwidthTest(int argc, char** argv) : BaseTest() {
 
   // Initialize version of the test
   version_.major_id = 2;
-  version_.minor_id = 3;
-  version_.step_id = 11;
+  version_.minor_id = 4;
+  version_.step_id = 0;
   version_.reserved = 0;
 
   bw_iter_cnt_ = getenv("ROCM_BW_ITER_CNT");
@@ -820,6 +820,9 @@ RocmBandwidthTest::RocmBandwidthTest(int argc, char** argv) : BaseTest() {
     }
     set_num_iteration(num);
   }
+
+  tscFreq = PerfTimer::MeasureTSCFreqHz();
+  //printf("TSC measure: %f \n", tscFreq);
 
   exit_value_ = 0;
 }

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -519,6 +519,9 @@ class RocmBandwidthTest : public BaseTest {
   // Flag to print Cpu time
   bool print_cpu_time_;
 
+  // tsc freq
+  double tscFreq;
+
   // Determines if user has requested initialization
   bool init_;
 


### PR DESCRIPTION
__What__
Add ROCM_HOME parameter to specify the ROCm installed root on cmake. For example, to configure build for ROCm 3.7.0 APIs/libraries, use:
  cmake -DROCM_HOME=/opt/rocm-3.7.0 <etc>
The default "/opt/rocm" will be used when ROCM_HOME is not specified.

Remove giant triple-nested loops chewing up CPU cycles when running benchmark and skewing timing of interrupts/signals causing erratic results on certain platforms. The TSCFreq calculation, which uses a huge loop is calculated once per run instead of for every iteration/transaction.
Calculating TSCFreq makes the rocm-bandwidth-test 2.4.0 run much faster!

Update version to 2.4.0

__Why__
Multiple ROCm releases can be installed on a system. Each ROCm release under their own top level directory, such as /opt/rocm-3.3.0, /opt/rocm-3.5.0, etc. It is important to set runpath when building applications to link with the specific ROCm version it is intended to, and load those specific versions of libraries at runtime as well to avoid impact of any incompatible changes in libraries/APIs.

__How__
Use ROCM_HOME to specify the top level ROCm installed directory. The cmake find_package uses it to find hsa-runtime64 cmake targets.

After building the applications, run
  ldd rocm-bandwidth-test
to verify that the libraries are picked from the ROCM_HOME location.

At runtime, a user shall use LD_LIBRARY_PATH to direct loader if needed.