### PR TITLE
Standardizing Package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.6.3)
 
 #
 #  Setup build environment
@@ -147,7 +147,6 @@ get_version()
 # Bind the Major, Minor and Patch values
 set(BUILD_VERSION_MAJOR ${VERSION_MAJOR})
 set(BUILD_VERSION_MINOR ${VERSION_MINOR})
-set(BUILD_VERSION_PATCH ${VERSION_PATCH})
 
 # Basic Tool Chain Information
 message(" ")
@@ -182,24 +181,50 @@ install(TARGETS ${TEST_NAME} RUNTIME DESTINATION bin)
 
 # Add packaging directives for rocm_bandwidth_test
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
-set(CPACK_PACKAGE_VENDOR "AMD")
+set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")
 set(CPACK_PACKAGE_VERSION_MAJOR ${BUILD_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${BUILD_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${BUILD_VERSION_PATCH})
-set(CPACK_PACKAGE_CONTACT "Advanced Micro Devices Inc.")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Test to measure PciE bandwidth on ROCm platforms")
+set(CPACK_PACKAGE_CONTACT "TODO <Add a valid email id>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Diagnostic utility tool to measure PCIe bandwidth on ROCm platforms")
+
+#Make proper version for appending
+#Default Value is 99999, setting it first
+set(ROCM_VERSION_FOR_PACKAGE "99999")
+if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
+  set(ROCM_VERSION_FOR_PACKAGE $ENV{ROCM_LIBPATCH_VERSION})
+endif()
 
 # Debian package specific variables
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev" )
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/RadeonOpenCompute/rocm_bandwidth_test")
+if (DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+   set(CPACK_DEBIAN_PACKAGE_RELEASE $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
+else()
+   set(CPACK_DEBIAN_PACKAGE_RELEASE "local")
+endif()
 
 # RPM package specific variables
 set(CPACK_RPM_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev" )
-
-# RPM package specific variables
 if(DEFINED CPACK_PACKAGING_INSTALL_PREFIX)
   set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INSTALL_PREFIX} ${CPACK_PACKAGING_INSTALL_PREFIX}/bin")
 endif()
+if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
+  set(CPACK_RPM_PACKAGE_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
+else()
+  set(CPACK_RPM_PACKAGE_RELEASE "local")
+endif()
+
+#Set rpm distro
+if(CPACK_RPM_PACKAGE_RELEASE)
+  set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
+endif()
+
+#Prepare final version for the CAPACK use
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}.${ROCM_VERSION_FOR_PACKAGE}")
+
+#Set the names now using CPACK utility
+set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 
 include(CPack)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.6.3)
-
 #
 #  Setup build environment
 #
@@ -166,14 +165,14 @@ add_executable(${TEST_NAME} ${Src})
 if(${hsa-runtime64_FOUND})
    target_link_libraries(${TEST_NAME} PRIVATE hsa-runtime64::hsa-runtime64)
 else()
-   target_link_libraries(${TEST_NAME} PRIVATE ${ROCR_LIB} ${ROCT_LIB} )
+   target_link_libraries(${TEST_NAME} PRIVATE ${ROCR_LIB} ${ROCT_LIB})
 endif()
 target_link_libraries(${TEST_NAME} PRIVATE c stdc++ dl pthread rt)
 
 # Update linker flags to include RPATH
 # Add --enable-new-dtags to generate DT_RUNPATH
 if( DEFINED ENV{ROCM_RPATH})
-   set ( CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
+   set ( CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}")
 endif()
 
 # Add install directives for rocm_bandwidth_test
@@ -196,7 +195,7 @@ if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
 endif()
 
 # Debian package specific variables
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev" )
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/RadeonOpenCompute/rocm_bandwidth_test")
 if (DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
    set(CPACK_DEBIAN_PACKAGE_RELEASE $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
@@ -205,7 +204,7 @@ else()
 endif()
 
 # RPM package specific variables
-set(CPACK_RPM_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev" )
+set(CPACK_RPM_PACKAGE_DEPENDS "libstdc++6, hsa-rocr-dev")
 if(DEFINED CPACK_PACKAGING_INSTALL_PREFIX)
   set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INSTALL_PREFIX} ${CPACK_PACKAGING_INSTALL_PREFIX}/bin")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,10 @@ include(utils)
 find_package(hsa-runtime64
    PATHS  /opt/rocm )
 if(${hsa-runtime64_FOUND})
-  message("hsa-runtime64 found @  ${hsa-runtime64_DIR} " )
+  message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
 else()
-  message("hsa-runtime64 NOT found Resolving to OLD Way" )
-  find_path(ROCR_HDR hsa.h PATHS "/opt/rocm" PATH_SUFFIXES include/hsa  REQUIRED )
+  message("hsa-runtime64 NOT found Resolving to OLD Way")
+  find_path(ROCR_HDR hsa.h PATHS "/opt/rocm" PATH_SUFFIXES include/hsa  REQUIRED)
   INCLUDE_DIRECTORIES(${ROCR_HDR})
   # Search for ROCr library file
   find_library(ROCR_LIB ${CORE_RUNTIME_TARGET} PATHS "/opt/rocm" PATH_SUFFIXES lib lib64 REQUIRED)
@@ -171,8 +171,8 @@ target_link_libraries(${TEST_NAME} PRIVATE c stdc++ dl pthread rt)
 
 # Update linker flags to include RPATH
 # Add --enable-new-dtags to generate DT_RUNPATH
-if( DEFINED ENV{ROCM_RPATH})
-   set ( CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}")
+if(DEFINED ENV{ROCM_RPATH})
+   set(CMAKE_EXE_LINKER_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}")
 endif()
 
 # Add install directives for rocm_bandwidth_test
@@ -187,8 +187,8 @@ set(CPACK_PACKAGE_VERSION_PATCH ${BUILD_VERSION_PATCH})
 set(CPACK_PACKAGE_CONTACT "TODO <Add a valid email id>")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Diagnostic utility tool to measure PCIe bandwidth on ROCm platforms")
 
-#Make proper version for appending
-#Default Value is 99999, setting it first
+# Make proper version for appending
+# Default Value is 99999, setting it first
 set(ROCM_VERSION_FOR_PACKAGE "99999")
 if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
   set(ROCM_VERSION_FOR_PACKAGE $ENV{ROCM_LIBPATCH_VERSION})
@@ -214,15 +214,15 @@ else()
   set(CPACK_RPM_PACKAGE_RELEASE "local")
 endif()
 
-#Set rpm distro
+# Set rpm distro
 if(CPACK_RPM_PACKAGE_RELEASE)
   set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
 endif()
 
-#Prepare final version for the CAPACK use
+# Prepare final version for the CAPACK use
 set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}.${ROCM_VERSION_FOR_PACKAGE}")
 
-#Set the names now using CPACK utility
+# Set the names now using CPACK utility
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 

--- a/cmake_modules/utils.cmake
+++ b/cmake_modules/utils.cmake
@@ -76,6 +76,7 @@ function( parse_version VERSION_STRING )
   if ( ${TOKEN_COUNT} GREATER 2 )
     list ( GET TOKENS 2 PATCH )
     set ( VERSION_PATCH ${PATCH} PARENT_SCOPE )
+    set ( BUILD_VERSION_PATCH "${PATCH}" CACHE STRING "Setting the patch version" FORCE )
   endif ()
 
   # Return if commit info is not present


### PR DESCRIPTION
Enables standards compliant package naming for Debian and rpm.

Tested to be producing following on Debian(Ubuntu) builds:
rocm-bandwidth-test_1.4.0.99999-local.9999_amd64.deb
rocm-bandwidth-test-1.4.0.99999-local.9999.x86_64.rpm

And
The following on CentOS builds:
rocm-bandwidth-test_1.4.0.99999-local.9999_amd64.deb
rocm-bandwidth-test-1.4.0.99999-local.9999.el8.x86_64.rpm
