### PR TITLE
SWDEV-345870 - Correct include paths for new directory layout

### DIFF
--- a/base_test.hpp
+++ b/base_test.hpp
@@ -43,7 +43,7 @@
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
 
-#include "hsa.h"
+#include "hsa/hsa.h"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/common.hpp
+++ b/common.hpp
@@ -48,8 +48,8 @@
 #include <vector>
 #include <cmath>
 #include <stdio.h>
-#include "hsa.h"
-#include "hsa_ext_amd.h"
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
 
 using namespace std;
 

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -43,7 +43,7 @@
 #ifndef __ROC_BANDWIDTH_TEST_H__
 #define __ROC_BANDWIDTH_TEST_H__
 
-#include "hsa.h"
+#include "hsa/hsa.h"
 #include "base_test.hpp"
 #include "common.hpp"
 


### PR DESCRIPTION
With file reorganization, the header files are moved to /opt/rocm-xyz/include/comp_name/
The hsa header files referred are wrapper files and will generate a warning on compilation. Changes made to refer actual header files