### PR TITLE
Added backward compatibility for hsa header include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,12 @@ if(${hsa-runtime64_FOUND})
   set(RBT_HSA_VERSION_MAJ ${hsa-runtime64_VERSION_MAJOR} )
   set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
   set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
-  #with File reorg changes /opt/rocm-ver/include/hsa/ will have actual hsa header files
-  #/opt/rocm-ver/hsa/include/hsa/ will have wrapper header files.
-  #Rocm 5.3.0 will have hsa file reorg changes. The corresponding package version is 1056300
+  #with File reorg changes
+  # Actual header files  /opt/rocm-ver/include/hsa/
+  # Wrapper header file  /opt/rocm-ver/hsa/include/hsa/
+  # Rocm 5.3.0 will have hsa file reorg changes. Corresponding HSA package version is 1056300
+  # if hsa package version is greater than or equal to file reorg version ,use actual files
+  # else use wrapper files. For Default/failure cases use actual files
   math(EXPR RBT_HSA_VERSION_FILEREORG "1056300")
   add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,25 +135,24 @@ include(utils)
 # build system relies on user defined locations to find header and library files
 find_package(hsa-runtime64 PATHS /opt/rocm )
 if(${hsa-runtime64_FOUND})
-  #hsa-runtime config files will provide the include path via INSTALL_INTERFACE
+  # hsa-runtime config files will provide the include path via INSTALL_INTERFACE
   message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
   set(RBT_HSA_VERSION_MAJ ${hsa-runtime64_VERSION_MAJOR} )
   set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
   set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
-  #with File reorg changes
+  # With file reorg changes
   # Actual header files  /opt/rocm-ver/include/hsa/
   # Wrapper header file  /opt/rocm-ver/hsa/include/hsa/
-  # Rocm 5.3.0 will have hsa file reorg changes. Corresponding HSA package version is 1056300
-  # if hsa package version is greater than or equal to file reorg version ,use actual files
-  # else use wrapper files. For Default/failure cases use actual files
+  # Rocm 5.3.0 will have Hsa file reorg changes. Corresponding Hsa package version is 1056300
+  # If hsa package version greater than or equal to file reorg version,use hsa/hsa.h else use hsa.h
   math(EXPR RBT_HSA_VERSION_FILEREORG "1056300")
   add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
 
   if( (RBT_HSA_VERSION_MAJ GREATER 999) OR (RBT_HSA_VERSION_MIN GREATER 999) )
-    #Build will fail ,if package version is invalid
+    # Build will fail ,if package version is invalid
     message(FATAL_ERROR "RBT hsa-runtime64: Too big HSA runtime version number(s)" )
   else() # if valid hsa  package version
-     #find the hsa package version and set flat version
+     # find the hsa package version and set flat version
     math(EXPR RBT_HSA_VERSION_FLAT  "(${RBT_HSA_VERSION_MAJ}*1000000+${RBT_HSA_VERSION_MIN}*1000+${RBT_HSA_VERSION_PATCH})" )
     add_compile_options(-DRBT_HSA_VERSION_FLAT=${RBT_HSA_VERSION_FLAT})
   endif()
@@ -163,7 +162,7 @@ else()
   message("Looking for library files in ${ROCR_LIB_DIR}")
 
   # Search for ROCr header file in user defined locations
-  #since the search is for hsa/hsa.h and the default include is "hsa/hsa.h", this will support all version of rocm
+  # Since the search is for hsa/hsa.h and the default include is "hsa/hsa.h", this will support all version of rocm
   find_path(ROCR_HDR hsa/hsa.h PATHS ${ROCR_INC_DIR} "/opt/rocm" PATH_SUFFIXES include REQUIRED)
   INCLUDE_DIRECTORIES(${ROCR_HDR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,13 +136,26 @@ include(utils)
 find_package(hsa-runtime64 PATHS /opt/rocm )
 if(${hsa-runtime64_FOUND})
   message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
+  set(RBT_HSA_VERSION_MAJ ${hsa-runtime64_VERSION_MAJOR} )
+  set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
+  set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
+  #Rocm 5.3.0 will have hsa file reorg changes. The package version is 1055300
+  math(EXPR RBT_HSA_VERSION_FILEREORG "1055300")
+  add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
+
+  if( (RBT_HSA_VERSION_MAJ GREATER 999) OR (RBT_HSA_VERSION_MIN GREATER 999) )
+    message(FATAL_ERROR "RBT hsa-runtime64: Too big HSA runtime version number(s)" )
+  else() #if Valid hsa Version flags
+    math(EXPR RBT_HSA_VERSION_FLAT  "(${RBT_HSA_VERSION_MAJ}*1000000+${RBT_HSA_VERSION_MIN}*1000+${RBT_HSA_VERSION_PATCH})" )
+    add_compile_options(-DRBT_HSA_VERSION_FLAT=${RBT_HSA_VERSION_FLAT})
+  endif()
 else()
   message("find_package did NOT find hsa-runtime64, finding it the OLD Way")
   message("Looking for header files in ${ROCR_INC_DIR}")
   message("Looking for library files in ${ROCR_LIB_DIR}")
 
   # Search for ROCr header file in user defined locations
-  find_path(ROCR_HDR hsa.h PATHS ${ROCR_INC_DIR} "/opt/rocm" PATH_SUFFIXES include/hsa REQUIRED)
+  find_path(ROCR_HDR hsa/hsa.h PATHS ${ROCR_INC_DIR} "/opt/rocm" PATH_SUFFIXES include REQUIRED)
   INCLUDE_DIRECTORIES(${ROCR_HDR})
   
   # Search for ROCr library file in user defined locations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ cmake_minimum_required(VERSION 3.6.3)
 #
 #  1) Setup cmake variable CMAKE_PREFIX_PATH to point to a root
 #     directory that has ROCr header and ROCr libraries
-#     
+#
 #     export CMAKE_PREFIX_PATH="Path to ROCr Header and ROCr libraries"
-#     
+#
 #       e.g. export CMAKE_PREFIX_PATH=/opt/rocm/
 #       e.g. export CMAKE_PREFIX_PATH=${HOME}/git/compute/out/ubuntu-16.04/16.04/
 #
@@ -135,17 +135,22 @@ include(utils)
 # build system relies on user defined locations to find header and library files
 find_package(hsa-runtime64 PATHS /opt/rocm )
 if(${hsa-runtime64_FOUND})
+  #hsa-runtime config files will provide the include path via INSTALL_INTERFACE
   message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
   set(RBT_HSA_VERSION_MAJ ${hsa-runtime64_VERSION_MAJOR} )
   set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
   set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
-  #Rocm 5.3.0 will have hsa file reorg changes. The package version is 1055300
+  #with File reorg changes /opt/rocm-ver/include/hsa/ will have actual hsa header files
+  #/opt/rocm-ver/hsa/include/hsa/ will have wrapper header files.
+  #Rocm 5.3.0 will have hsa file reorg changes. The corresponding package version is 1056300
   math(EXPR RBT_HSA_VERSION_FILEREORG "1056300")
   add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
 
   if( (RBT_HSA_VERSION_MAJ GREATER 999) OR (RBT_HSA_VERSION_MIN GREATER 999) )
+    #Build will fail ,if package version is invalid
     message(FATAL_ERROR "RBT hsa-runtime64: Too big HSA runtime version number(s)" )
-  else() #if Valid hsa Version flags
+  else() # if valid hsa  package version
+     #find the hsa package version and set flat version
     math(EXPR RBT_HSA_VERSION_FLAT  "(${RBT_HSA_VERSION_MAJ}*1000000+${RBT_HSA_VERSION_MIN}*1000+${RBT_HSA_VERSION_PATCH})" )
     add_compile_options(-DRBT_HSA_VERSION_FLAT=${RBT_HSA_VERSION_FLAT})
   endif()
@@ -155,9 +160,10 @@ else()
   message("Looking for library files in ${ROCR_LIB_DIR}")
 
   # Search for ROCr header file in user defined locations
+  #since the search is for hsa/hsa.h and the default include is "hsa/hsa.h", this will support all version of rocm
   find_path(ROCR_HDR hsa/hsa.h PATHS ${ROCR_INC_DIR} "/opt/rocm" PATH_SUFFIXES include REQUIRED)
   INCLUDE_DIRECTORIES(${ROCR_HDR})
-  
+
   # Search for ROCr library file in user defined locations
   find_library(ROCR_LIB ${CORE_RUNTIME_TARGET} PATHS ${ROCR_LIB_DIR} "/opt/rocm" PATH_SUFFIXES lib lib64 REQUIRED)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if(${hsa-runtime64_FOUND})
   set(RBT_HSA_VERSION_MIN ${hsa-runtime64_VERSION_MINOR} )
   set(RBT_HSA_VERSION_PATCH ${hsa-runtime64_VERSION_PATCH} )
   #Rocm 5.3.0 will have hsa file reorg changes. The package version is 1055300
-  math(EXPR RBT_HSA_VERSION_FILEREORG "1055300")
+  math(EXPR RBT_HSA_VERSION_FILEREORG "1056300")
   add_compile_options(-DRBT_HSA_VERSION_FILEREORG=${RBT_HSA_VERSION_FILEREORG})
 
   if( (RBT_HSA_VERSION_MAJ GREATER 999) OR (RBT_HSA_VERSION_MIN GREATER 999) )

--- a/base_test.hpp
+++ b/base_test.hpp
@@ -42,10 +42,12 @@
 
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
-
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+//HSA package with out file reorganization . Its for backward compatibility
+//This will be deprecated from future release
 #include "hsa.h"
 #else
+//HSA package with file reorganization
 #include "hsa/hsa.h"
 #endif
 #include <iostream>

--- a/base_test.hpp
+++ b/base_test.hpp
@@ -43,11 +43,11 @@
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-//HSA package with out file reorganization . Its for backward compatibility
-//This will be deprecated from future release
+// Hsa package with out file reorganization
+// This is for backward compatibility and will be deprecated from future release
 #include "hsa.h"
 #else
-//HSA package with file reorganization
+// Hsa package with file reorganization
 #include "hsa/hsa.h"
 #endif
 #include <iostream>

--- a/base_test.hpp
+++ b/base_test.hpp
@@ -43,7 +43,11 @@
 #ifndef ROC_BANDWIDTH_TEST_BASE_H_
 #define ROC_BANDWIDTH_TEST_BASE_H_
 
+#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+#include "hsa.h"
+#else
 #include "hsa/hsa.h"
+#endif
 #include <iostream>
 #include <string>
 #include <vector>

--- a/common.hpp
+++ b/common.hpp
@@ -49,12 +49,12 @@
 #include <cmath>
 #include <stdio.h>
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-//HSA package with out file reorganization. Its for backward compatibility
-//This will be deprecated from future release
+// Hsa package with out file reorganization
+// This is for backward compatibility and will be deprecated from future release
 #include "hsa.h"
 #include "hsa_ext_amd.h"
 #else
-//HSA package with file reorganization
+// Hsa package with file reorganization
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 #endif

--- a/common.hpp
+++ b/common.hpp
@@ -48,8 +48,13 @@
 #include <vector>
 #include <cmath>
 #include <stdio.h>
+#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+#include "hsa.h"
+#include "hsa_ext_amd.h"
+#else
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
+#endif
 
 using namespace std;
 

--- a/common.hpp
+++ b/common.hpp
@@ -49,9 +49,12 @@
 #include <cmath>
 #include <stdio.h>
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+//HSA package with out file reorganization. Its for backward compatibility
+//This will be deprecated from future release
 #include "hsa.h"
 #include "hsa_ext_amd.h"
 #else
+//HSA package with file reorganization
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 #endif

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -44,8 +44,11 @@
 #define __ROC_BANDWIDTH_TEST_H__
 
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+//HSA package with out file reorganization . Its for backward compatibility
+//This will be deprecated from future release
 #include "hsa.h"
 #else
+//HSA package with file reorganization
 #include "hsa/hsa.h"
 #endif
 #include "base_test.hpp"

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -43,7 +43,11 @@
 #ifndef __ROC_BANDWIDTH_TEST_H__
 #define __ROC_BANDWIDTH_TEST_H__
 
+#if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
+#include "hsa.h"
+#else
 #include "hsa/hsa.h"
+#endif
 #include "base_test.hpp"
 #include "common.hpp"
 

--- a/rocm_bandwidth_test.hpp
+++ b/rocm_bandwidth_test.hpp
@@ -44,11 +44,11 @@
 #define __ROC_BANDWIDTH_TEST_H__
 
 #if(defined(RBT_HSA_VERSION_FLAT) && ((RBT_HSA_VERSION_FLAT) < RBT_HSA_VERSION_FILEREORG))
-//HSA package with out file reorganization . Its for backward compatibility
-//This will be deprecated from future release
+// Hsa package with out file reorganization
+// This is for backward compatibility and will be deprecated from future release
 #include "hsa.h"
 #else
-//HSA package with file reorganization
+// Hsa package with file reorganization
 #include "hsa/hsa.h"
 #endif
 #include "base_test.hpp"


### PR DESCRIPTION
Hsa header include path is based on Hsa package version
Use "hsa.h" as include path if Hsa package version is lower than 1056300
Use "hsa/hsa.h" as include path if Hsa package version is 1056300 or higher
Hsa package version 1056300 will be available from 5.3.0 onwards

Validation:
    Hsa package version lower than 1056300 implies older build scheme
    Hsa package version 1056300 and higher implies newer build scheme
    Tested rocm-bandwidth-test build for both old and new schemes
    Build log has warning message when using old build scheme
    Build log does not have any warning message for header include when using new scheme